### PR TITLE
Remove condition 'response.data.indexOf('errorcode')' because it give…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ const getInfo = async ({ url, throwOnError = false }) => {
             params: { v: videoId }
         });
 
-        if (!response || response.status != 200 || !response.data || response.data.indexOf('errorcode') > -1) {
+        if (!response || response.status != 200 || !response.data) {
             const error = new Error('Cannot get youtube video response')
             error.response = response;
             throw error;


### PR DESCRIPTION
…s false negatives

Valid responses of some streams contain the word 'errorcode' and should not be used to invalidate a response. Example stream: 'xFrGuyw1V8s'